### PR TITLE
[PDX-401] Handle collection

### DIFF
--- a/NineChroniclesUtilBackend/Arena/ArenaBulkSimulator.cs
+++ b/NineChroniclesUtilBackend/Arena/ArenaBulkSimulator.cs
@@ -2,6 +2,9 @@ using Nekoyume.Model;
 using Nekoyume.TableData;
 using Nekoyume.Model.BattleStatus.Arena;
 using Nekoyume.Arena;
+using Libplanet.Crypto;
+using Nekoyume.Model.Stat;
+using Nekoyume.Model.State;
 using SimulatorRandom = NineChroniclesUtilBackend.Random;
 using SystemRandom = System.Random;
 
@@ -10,20 +13,25 @@ namespace NineChroniclesUtilBackend.Arena;
 public class ArenaBulkSimulator
 {
     private readonly int _rounds;
-    private const int TotalSimulations = 700;
+    private const int TotalSimulations = 1000;
 
     public ArenaBulkSimulator(int rounds = 5)
     {
         _rounds = rounds;
     }
 
-    public async Task<double> BulkSimulate(AvatarStatesForArena myAvatar, AvatarStatesForArena enemyAvatar, ArenaSimulatorSheets simulatorSheets)
+    public async Task<double> BulkSimulate(
+        AvatarStatesForArena myAvatar,
+        AvatarStatesForArena enemyAvatar,
+        ArenaSimulatorSheets simulatorSheets,
+        Dictionary<Address, CollectionState> collectionStates,
+        CollectionSheet collectionSheets)
     {
         int winCount = 0;
 
         var tasks = Enumerable.Range(0, TotalSimulations).Select(async _ =>
         {
-            var arenaLog = SimulateBattle(myAvatar, enemyAvatar, simulatorSheets);
+            var arenaLog = SimulateBattle(myAvatar, enemyAvatar, simulatorSheets, collectionStates, collectionSheets);
             if (arenaLog.Result == ArenaLog.ArenaResult.Win)
             {
                 Interlocked.Increment(ref winCount);
@@ -35,16 +43,40 @@ public class ArenaBulkSimulator
         return (double)winCount / TotalSimulations;
     }
 
-    public ArenaLog SimulateBattle(AvatarStatesForArena myAvatar, AvatarStatesForArena enemyAvatar, ArenaSimulatorSheets simulatorSheets)
+    public ArenaLog SimulateBattle(
+        AvatarStatesForArena myAvatar,
+        AvatarStatesForArena enemyAvatar,
+        ArenaSimulatorSheets simulatorSheets,
+        Dictionary<Address, CollectionState> collectionStates,
+        CollectionSheet collectionSheets)
     {
         var seed = new SystemRandom().Next();
         var random = new SimulatorRandom(seed);
         var simulator = new ArenaSimulator(random, _rounds);
+
+        var modifiers = new Dictionary<Address, List<StatModifier>>
+        {
+            [myAvatar.AvatarState.address] = new(),
+            [enemyAvatar.AvatarState.address] = new(),
+        };
+        if (collectionStates.Count > 0)
+        {
+            foreach (var (address, state) in collectionStates)
+            {
+                var modifier = modifiers[address];
+                foreach (var collectionId in state.Ids)
+                {
+                    modifier.AddRange(collectionSheets[collectionId].StatModifiers);
+                }
+            }
+        }
         
         var arenaLog = simulator.Simulate(
             new ArenaPlayerDigest(myAvatar.AvatarState, myAvatar.ItemSlotState.Equipments, myAvatar.ItemSlotState.Costumes, myAvatar.RuneStates),
             new ArenaPlayerDigest(enemyAvatar.AvatarState, enemyAvatar.ItemSlotState.Equipments, enemyAvatar.ItemSlotState.Costumes, enemyAvatar.RuneStates),
             simulatorSheets,
+            modifiers[myAvatar.AvatarState.address],
+            modifiers[enemyAvatar.AvatarState.address],
             true);
         
         return arenaLog;

--- a/NineChroniclesUtilBackend/NineChroniclesUtilBackend.csproj
+++ b/NineChroniclesUtilBackend/NineChroniclesUtilBackend.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.3.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Lib9c" Version="1.8.0-dev.4e2f5d9bfed5366a94e67b88c4b0e7171c0cd0d6" />
+    <PackageReference Include="Lib9c" Version="1.8.0-dev.04d6656b74af6476768a0f1f9980340ecccf12ee" />
     <PackageReference Include="Libplanet" Version="4.1.0-dev.20242745721" />
     <PackageReference Include="StrawberryShake" Version="13.8.1" />
     <PackageReference Include="StrawberryShake.Transport.Http" Version="13.8.1" />

--- a/NineChroniclesUtilBackend/Options/EmptyChronicleOption.cs
+++ b/NineChroniclesUtilBackend/Options/EmptyChronicleOption.cs
@@ -1,6 +1,0 @@
-namespace NineChroniclesUtilBackend.Options;
-
-public class EmptyChronicleOption
-{
-    public Uri Endpoint { get; set; }
-}

--- a/NineChroniclesUtilBackend/Program.cs
+++ b/NineChroniclesUtilBackend/Program.cs
@@ -14,7 +14,6 @@ builder.Configuration.AddEnvironmentVariables();
 
 builder.Services.Configure<HeadlessStateServiceOption>(builder.Configuration.GetRequiredSection("StateService"));
 builder.Services.Configure<DatabaseOption>(builder.Configuration.GetRequiredSection("Database"));
-builder.Services.Configure<EmptyChronicleOption>(builder.Configuration.GetRequiredSection("EmptyChronicle"));
 builder.Services.ConfigureHttpJsonOptions(options =>
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 

--- a/NineChroniclesUtilBackend/Repositories/ArenaRankingRespository.cs
+++ b/NineChroniclesUtilBackend/Repositories/ArenaRankingRespository.cs
@@ -1,17 +1,15 @@
-using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Nekoyume.Model.State;
 using NineChroniclesUtilBackend.Models.Agent;
 using NineChroniclesUtilBackend.Models.Arena;
-using NineChroniclesUtilBackend.Options;
 using NineChroniclesUtilBackend.Services;
 
 namespace NineChroniclesUtilBackend.Repositories;
 
-public class ArenaRankingRepository(MongoDBCollectionService mongoDBCollectionService, IOptions<EmptyChronicleOption> options)
+public class ArenaRankingRepository(MongoDBCollectionService mongoDBCollectionService, IStateService stateService)
 {
-    private CpRepository cpRepository = new CpRepository(options.Value.Endpoint);
+    private CpRepository cpRepository = new CpRepository(stateService);
 
     private readonly IMongoCollection<dynamic> ArenaCollection =
         mongoDBCollectionService.GetCollection<dynamic>("arena");

--- a/NineChroniclesUtilBackend/Repositories/CpRepository.cs
+++ b/NineChroniclesUtilBackend/Repositories/CpRepository.cs
@@ -1,23 +1,23 @@
-using System.Text.Json.Nodes;
-using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
-using Nekoyume;
 using Nekoyume.Battle;
 using Nekoyume.Model.Item;
+using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using NineChroniclesUtilBackend.Models.Agent;
+using NineChroniclesUtilBackend.Services;
+using NineChroniclesUtilBackend.Util;
 
 namespace NineChroniclesUtilBackend.Repositories;
 
 public class CpRepository
 {
-    private Uri emptyChronicleEndpoint { get; set; }
+    private StateGetter _stateGetter;
 
-    public CpRepository(Uri _emptyChronicleEndpoint)
+    public CpRepository(IStateService stateService)
     {
-        emptyChronicleEndpoint = _emptyChronicleEndpoint;
+        _stateGetter = new StateGetter(stateService);
     }
 
     public async Task<int?> CalculateCp(
@@ -30,20 +30,28 @@ public class CpRepository
     {
         try
         {
-            var inventory = await GetInventory(avatar.AvatarAddress);
-            var equipments = equipmentIds
-                .Select(x => inventory.GetValueOrDefault(x))
-                .Where(x => x != null)
-                .Select(x => new Equipment(x))
-                .Where(x => x.Equipped);
-            var costumes = costumeIds
-                .Select(x => inventory.GetValueOrDefault(x))
-                .Where(x => x != null)
-                .Select(x => new Costume(x))
-                .Where(x => x.Equipped);
-            var runes = runeOption.Select(x => GetRuneOptionInfo(x.id, x.level).Result);
+            var avatarAddress = new Address(avatar.AvatarAddress);
+
             var characterRow = await GetCharacterRow(characterId);
-            var costumeStatSheet = await GetSheet(new CostumeStatSheet());
+            var costumeStatSheet = await _stateGetter.GetSheet<CostumeStatSheet>();
+            var collectionSheets = await _stateGetter.GetSheet<CollectionSheet>();
+
+            var inventoryState = await _stateGetter.GetInventoryState(avatarAddress);
+
+            List<Equipment> equipments = inventoryState
+                .Equipments
+                .Where(x => x.Equipped).ToList();
+            List<Costume> costumes = inventoryState
+                .Costumes
+                .Where(x => x.Equipped).ToList();
+            List<RuneOptionSheet.Row.RuneOptionInfo> runes = runeOption.Select(x => GetRuneOptionInfo(x.id, x.level).Result).ToList();
+            var collectionState = await _stateGetter.GetCollectionStates([avatarAddress]);
+
+            List<StatModifier> modifier = [];
+            foreach (var collectionId in collectionState[avatarAddress].Ids)
+            {
+                modifier.AddRange(collectionSheets[collectionId].StatModifiers);
+            }
 
             return CPHelper.TotalCP(
                 equipments,
@@ -51,7 +59,8 @@ public class CpRepository
                 runes,
                 avatar.Level,
                 characterRow,
-                costumeStatSheet
+                costumeStatSheet,
+                modifier
             );
         }
         catch (NullReferenceException)
@@ -60,31 +69,12 @@ public class CpRepository
         }
     }
 
-    private async Task<Dictionary<string, Dictionary>> GetInventory(string address)
-    {
-        var inventoryState = await GetInventoryState(address);
-
-        return inventoryState
-            .Select(x => (Dictionary)((Dictionary)x)["item"])
-            .Where(x =>
-                ((Text)x["item_type"]).Value == "Costume"
-                || ((Text)x["item_type"]).Value == "Equipment"
-            )
-            .ToDictionary(x =>
-            {
-                if (((Text)x["item_type"]).Value == "Costume")
-                    return ((Binary)x["item_id"]).ToGuid().ToString();
-
-                return ((Binary)x["itemId"]).ToGuid().ToString();
-            });
-    }
-
     private async Task<RuneOptionSheet.Row.RuneOptionInfo> GetRuneOptionInfo(
         int id,
         int level
     )
     {
-        var sheets = await GetSheet(new RuneOptionSheet());
+        var sheets = await _stateGetter.GetSheet<RuneOptionSheet>();
 
         if (!sheets.TryGetValue(id, out var optionRow))
         {
@@ -101,7 +91,7 @@ public class CpRepository
 
     private async Task<CharacterSheet.Row> GetCharacterRow(int characterId)
     {
-        var sheets = await GetSheet(new CharacterSheet());
+        var sheets = await _stateGetter.GetSheet<CharacterSheet>();
 
         if (!sheets.TryGetValue(characterId, out var row))
         {
@@ -110,42 +100,4 @@ public class CpRepository
 
         return row;
     }
-
-    private async Task<T> GetSheet<T>(T sheets)
-        where T : ISheet
-    {
-        var sheetsAddress = Addresses.GetSheetAddress<T>();
-        var rawSheets = await GetState<Text>(sheetsAddress);
-        sheets.Set(rawSheets);
-
-        return sheets;
-    }
-
-    private async Task<T> GetState<T>(Address address, string? account = null)
-        where T : IValue => await GetState<T>(address.ToString(), account);
-
-    // TODO: Cache
-    private async Task<T?> GetState<T>(string address, string? account = null)
-        where T : IValue
-    {
-        var codec = new Codec();
-        var url =
-            account == null
-                ? $"{emptyChronicleEndpoint.AbsoluteUri}api/states/{address}/raw"
-                : $"{emptyChronicleEndpoint.AbsoluteUri}api/states/{address}/raw?account={account}";
-        var client = new HttpClient();
-        var response = await client.GetAsync(url);
-        var json = JsonNode.Parse(await response.Content.ReadAsStringAsync());
-        var rawValue = json["value"]?.GetValue<string>();
-        if (rawValue == null || rawValue == "")
-        {
-            throw new NullReferenceException();
-        }
-        var value = codec.Decode(Convert.FromHexString(rawValue));
-
-        return (T)value;
-    }
-
-    private async Task<List> GetInventoryState(string address) =>
-        await GetState<List?>(address, Addresses.Inventory.ToString()) ?? [];
 }

--- a/NineChroniclesUtilBackend/Services/HeadlessStateService.cs
+++ b/NineChroniclesUtilBackend/Services/HeadlessStateService.cs
@@ -21,9 +21,19 @@ public class HeadlessStateService(IHeadlessGQLClient client) : IStateService
         return Task.WhenAll(addresses.Select(GetState));
     }
 
+    public Task<IValue?[]> GetStates(Address[] addresses, Address accountAddress)
+    {
+        return Task.WhenAll(addresses.Select(addr => GetState(addr, accountAddress)));
+    }
+
     public async Task<IValue?> GetState(Address address)
     {
-        var result = await client.GetState.ExecuteAsync(ReservedAddresses.LegacyAccount.ToString(), address.ToString());
+        return await GetState(address, ReservedAddresses.LegacyAccount);
+    }
+
+    public async Task<IValue?> GetState(Address address, Address accountAddress)
+    {
+        var result = await client.GetState.ExecuteAsync(accountAddress.ToString(), address.ToString());
         result.EnsureNoErrors();
 
         if (result.Data?.State is null)

--- a/NineChroniclesUtilBackend/Services/IStateService.cs
+++ b/NineChroniclesUtilBackend/Services/IStateService.cs
@@ -6,6 +6,8 @@ namespace NineChroniclesUtilBackend.Services;
 
 public interface IStateService
 {
-    Task<IValue?[]> GetStates(Address[] addresses);
     Task<IValue?> GetState(Address address);
+    Task<IValue?> GetState(Address address, Address accountAddress);
+    Task<IValue?[]> GetStates(Address[] addresses);
+    Task<IValue?[]> GetStates(Address[] addresses, Address accountAddress);
 }

--- a/NineChroniclesUtilBackend/Util/StateGetter.cs
+++ b/NineChroniclesUtilBackend/Util/StateGetter.cs
@@ -1,0 +1,160 @@
+using Libplanet.Crypto;
+using Bencodex.Types;
+using Nekoyume.TableData;
+using Nekoyume;
+using Nekoyume.Action;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using NineChroniclesUtilBackend.Services;
+
+namespace NineChroniclesUtilBackend.Util;
+
+public class StateGetter
+{
+    private readonly IStateService _stateService;
+
+    public StateGetter(IStateService stateService)
+    {
+        _stateService = stateService;
+    }
+
+    public async Task<T> GetSheet<T>()
+        where T : ISheet, new()
+    {
+        var sheetState = await _stateService.GetState(
+            Addresses.TableSheet.Derive(typeof(T).Name)
+        );
+        if (sheetState is not Text sheetValue)
+        {
+            throw new ArgumentException(nameof(T));
+        }
+
+        var sheet = new T();
+        sheet.Set(sheetValue.Value);
+        return sheet;
+    }
+
+    public async Task<AvatarState> GetAvatarState(Address avatarAddress)
+    {
+        var state = await GetStateWithLegacyAccount(avatarAddress, Addresses.Avatar);
+        var inventory = await GetInventoryState(avatarAddress);
+        
+        AvatarState avatarState;
+        if (state is Dictionary dictionary)
+        {
+            avatarState = new AvatarState(dictionary)
+            {
+                inventory = inventory
+            };
+        }
+        else if (state is List alist)
+        {
+            avatarState = new AvatarState(alist)
+            {
+                inventory = inventory
+            };
+        }
+        else
+        {
+            throw new ArgumentException($"Unsupported state type for address: {avatarAddress}");
+        }
+
+        return avatarState;
+    }
+
+    public async Task<Inventory> GetInventoryState(Address avatarAddress)
+    {
+
+        var legacyInventoryAddress = avatarAddress.Derive("inventory");
+        var rawState = await GetAvatarStateWithLegacyAccount(
+            avatarAddress, Addresses.Inventory, legacyInventoryAddress);
+
+        if (rawState is not List list)
+        {
+            throw new ArgumentException(nameof(avatarAddress));
+        }
+
+        return new Inventory(list);
+    }
+
+    public async Task<ItemSlotState> GetItemSlotState(Address avatarAddress)
+    {
+        var state = await _stateService.GetState(
+            ItemSlotState.DeriveAddress(avatarAddress, BattleType.Arena));
+        return state switch
+        {
+            List list => new ItemSlotState(list),
+            null => new ItemSlotState(BattleType.Arena),
+            _ => throw new ArgumentException(nameof(avatarAddress))
+        };
+    }
+
+    public async Task<List<RuneState>> GetRuneStates(Address avatarAddress)
+    {
+        var state = await _stateService.GetState(
+            RuneSlotState.DeriveAddress(avatarAddress, BattleType.Arena));
+        var runeSlotState = state switch
+        {
+            List list => new RuneSlotState(list),
+            null => new RuneSlotState(BattleType.Arena),
+            _ => throw new ArgumentException(nameof(avatarAddress))
+        };
+
+        var runes = new List<RuneState>();
+        foreach (var runeStateAddress in runeSlotState.GetEquippedRuneSlotInfos().Select(info => RuneState.DeriveAddress(avatarAddress, info.RuneId)))
+        {
+            if (await _stateService.GetState(runeStateAddress) is List list)
+            {
+                runes.Add(new RuneState(list));
+            }
+        }
+
+        return runes;
+    }
+
+    public async Task<Dictionary<Address, CollectionState>> GetCollectionStates(List<Address> addresses)
+    {
+        var result = new Dictionary<Address, CollectionState>();
+
+        var values = await _stateService.GetStates(
+            addresses.ToArray(),
+            Addresses.Collection
+        );
+
+        for (int i = 0; i < addresses.Count; i++)
+        {
+            var serialized = values[i];
+            var address = addresses[i];
+
+            if (serialized is List bencoded)
+            {
+                result.TryAdd(address, new CollectionState(bencoded));
+            }
+        }
+        
+        return result;
+    }
+
+    public async Task<IValue?> GetStateWithLegacyAccount(Address address, Address accountAddress)
+    {
+        var state = await _stateService.GetState(address, accountAddress);
+        
+        if (state == null)
+        {
+            state = await _stateService.GetState(address);
+        }
+        return state;
+    }
+
+    public async Task<IValue?> GetAvatarStateWithLegacyAccount(Address avatarAddress, Address accountAddress, Address legacyAddress)
+    {
+        var state = await _stateService.GetState(avatarAddress, accountAddress);
+        
+        if (state == null)
+        {
+            state = await _stateService.GetState(legacyAddress);
+        }
+        return state;
+    }
+}


### PR DESCRIPTION
I've updated lib9c to the latest version and processed the collection data.
During the process, I removed the existing 0c dependency and temporarily modified it to handle it headlessly.
The reason is that there was too much duplication in the code fetching the state, so I aimed to make it more utilitarian and consolidate it.
Since it wouldn't work without addressing the previously unprocessed Account Address, I also carried out work on that in the same branch.