### PR TITLE
PDX-396: Update arena, avatar when `battle_arena*` occurred. 

### DIFF
--- a/NineChroniclesUtilBackend.Store/BlockPoller.cs
+++ b/NineChroniclesUtilBackend.Store/BlockPoller.cs
@@ -1,0 +1,69 @@
+using Bencodex.Types;
+using HeadlessGQL;
+using Libplanet.Crypto;
+using Libplanet.Types.Tx;
+using NineChroniclesUtilBackend.Store.Models;
+using NineChroniclesUtilBackend.Store.Scrapper;
+using NineChroniclesUtilBackend.Store.Services;
+
+namespace NineChroniclesUtilBackend.Store;
+
+public class BlockPoller(IStateService stateService, HeadlessGQLClient headlessGqlClient, MongoDbStore mongoDbStore)
+{
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var stateGetter = new StateGetter(stateService);
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var syncedBlockIndex = await mongoDbStore.GetLatestBlockIndex();
+            var currentBlockIndex = await stateService.GetLatestIndex();
+            var processBlockIndex = syncedBlockIndex + 1;
+
+            if (processBlockIndex >= currentBlockIndex)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(3000), cancellationToken);
+                continue;
+            }
+
+            var rawArenaTxsResp = await headlessGqlClient.GetBattleArenaTransactions.ExecuteAsync(processBlockIndex);
+
+            if (rawArenaTxsResp.Data is null)
+            {
+                Serilog.Log.Error("Failed to get arena txs. errors:\n" +
+                                  string.Join("\n", rawArenaTxsResp.Errors.Select(x => "- " + x.Message)));
+                await mongoDbStore.UpdateLatestBlockIndex(syncedBlockIndex + 1);
+                continue;
+            }
+
+            try
+            {
+                var arenaTxs = rawArenaTxsResp.Data.Transaction
+                    .NcTransactions!.Select(raw =>
+                        TxMarshaler.DeserializeTransactionWithoutVerification(
+                            Convert.FromBase64String(raw.SerializedPayload)))
+                    .ToList();
+
+                foreach (var arenaTx in arenaTxs)
+                {
+                    var arenaAction = (Dictionary)arenaTx.Actions.First();
+                    var arenaActionValues = (Dictionary)arenaAction["values"];
+                    var enemyAvatarAddress = new Address(arenaActionValues["eaa"]);
+                    var myAvatarAddress = new Address(arenaActionValues["maa"]);
+
+                    var roundData = await stateGetter.GetArenaRoundData(processBlockIndex);
+                    var enemyAvatarData = await stateGetter.GetAvatarData(enemyAvatarAddress);
+                    var myAvatarData = await stateGetter.GetAvatarData(myAvatarAddress);
+                    var myArenaData = await stateGetter.GetArenaData(roundData, myAvatarAddress);
+                    var enemyArenaData = await stateGetter.GetArenaData(roundData, enemyAvatarAddress);
+
+                    await mongoDbStore.BulkUpsertAvatarDataAsync(new List<AvatarData> { myAvatarData, enemyAvatarData });
+                    await mongoDbStore.BulkUpsertArenaDataAsync(new List<ArenaData> { myArenaData, enemyArenaData });
+                }
+            }
+            finally
+            {
+                await mongoDbStore.UpdateLatestBlockIndex(syncedBlockIndex + 1);
+            }
+        }
+    }
+}

--- a/NineChroniclesUtilBackend.Store/Initializer.cs
+++ b/NineChroniclesUtilBackend.Store/Initializer.cs
@@ -30,10 +30,7 @@ public class Initializer : BackgroundService
     {
         var started = DateTime.UtcNow;
 
-        if (!await _store.IsInitialized())
-        {
-            await _scrapper.ExecuteAsync(stoppingToken);   
-        }
+        await _scrapper.ExecuteAsync(stoppingToken);   
 
         var totalElapsedMinutes = DateTime.UtcNow.Subtract(started).Minutes;
         _logger.LogInformation($"Finished Initializer background service. Elapsed {totalElapsedMinutes} minutes.");

--- a/NineChroniclesUtilBackend.Store/Initializer.cs
+++ b/NineChroniclesUtilBackend.Store/Initializer.cs
@@ -28,7 +28,7 @@ public class Initializer : BackgroundService
 
         if (!await _store.IsInitialized())
         {
-            await _scrapper.ExecuteAsync();   
+            await _scrapper.ExecuteAsync(stoppingToken);   
         }
 
         var totalElapsedMinutes = DateTime.UtcNow.Subtract(started).Minutes;

--- a/NineChroniclesUtilBackend.Store/Queries.graphql
+++ b/NineChroniclesUtilBackend.Store/Queries.graphql
@@ -9,3 +9,11 @@ query GetTip {
 query GetState($accountAddress: Address! $address: Address!) {
     state(accountAddress: $accountAddress, address: $address)
 }
+
+query GetBattleArenaTransactions($blockIndex: Long!) {
+    transaction {
+        ncTransactions(startingBlockIndex: $blockIndex, limit: 1, actionType: "^battle_arena[0-9]*$") {
+            serializedPayload
+        }
+    }
+}

--- a/NineChroniclesUtilBackend.Store/Scrapper/ArenaScrapper.cs
+++ b/NineChroniclesUtilBackend.Store/Scrapper/ArenaScrapper.cs
@@ -13,7 +13,7 @@ public class ArenaScrapper(ILogger<ArenaScrapper> logger, IStateService service,
     private readonly IStateService _stateService = service;
     private readonly MongoDbStore _store = store;
 
-    public async Task ExecuteAsync()
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var latestBlockIndex = await service.GetLatestIndex();
         var stateGetter = _stateService.At();
@@ -38,6 +38,8 @@ public class ArenaScrapper(ILogger<ArenaScrapper> logger, IStateService service,
 
         foreach (var avatarAddress in arenaParticipants.AvatarAddresses)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var arenaData = await stateGetter.GetArenaData(roundData, avatarAddress);
             var avatarData = await stateGetter.GetAvatarData(avatarAddress);
 

--- a/NineChroniclesUtilBackend.Store/Services/MongoDbStore.cs
+++ b/NineChroniclesUtilBackend.Store/Services/MongoDbStore.cs
@@ -46,6 +46,7 @@ public class MongoDbStore
 
     public async Task UpdateLatestBlockIndex(long blockIndex)
     {
+        _logger.LogInformation($"Update latest block index to {blockIndex}");
         var filter = Builders<BsonDocument>.Filter.Eq("_id", "SyncContext");
         var update = Builders<BsonDocument>.Update.Set("LatestBlockIndex", blockIndex);
         var updateModel = new UpdateOneModel<BsonDocument>(filter, update);


### PR DESCRIPTION
This pull request does:

- Stop scrapping when cancellation requested.
- Update avatar, arena data by polling.
- Run scrapping every running. (start)